### PR TITLE
YASP: Fix spelling of brightness slider desc

### DIFF
--- a/res/values/yaap_strings.xml
+++ b/res/values/yaap_strings.xml
@@ -70,7 +70,7 @@
 
     <!-- Brightness slider -->
     <string name="qs_show_brightness_title">Brightness slider</string>
-    <string name="qs_show_brightness_summary">Brightness slider visability and settings</string>
+    <string name="qs_show_brightness_summary">Brightness slider visibility and settings</string>
     <string name="qs_brightness_position_bottom_title">Bottom brightness slider</string>
     <string name="qs_brightness_position_bottom_summary">Show the brightness slider on the bottom of QS</string>
     <string name="qs_show_brightness_above_footer_title">Above footer</string>


### PR DESCRIPTION
Fix spelling of 'visibility' in QS brightness slider description in YASP.